### PR TITLE
Add new auth-alias in order to use in the header while communicating with zds

### DIFF
--- a/charts/openforms2xxllnc/templates/configmap.openforms2xxllnc.specifics.yaml
+++ b/charts/openforms2xxllnc/templates/configmap.openforms2xxllnc.specifics.yaml
@@ -10,14 +10,17 @@ data:
   {{- with .beantwoordVraag }}
   openforms2xxllnc.connections.beantwoord-vraag.endpoint: "{{ .endpoint }}"
   openforms2xxllnc.connections.beantwoord-vraag.timeout: "{{ .timeout }}"
+  openforms2xxllnc.connections.beantwoord-vraag.auth-alias: "{{ .authAlias }}"
   {{- end }}
   {{- with .ontvangAsynchroon }}
   openforms2xxllnc.connections.ontvang-asynchroon.endpoint: "{{ .endpoint }}"
   openforms2xxllnc.connections.ontvang-asynchroon.timeout: "{{ .timeout }}"
+  openforms2xxllnc.connections.ontvang-asynchroon.auth-alias: "{{ .authAlias }}"
   {{- end }}
   {{- with .vrijeBerichten }}
   openforms2xxllnc.connections.vrije-berichten.endpoint: "{{ .endpoint }}"
   openforms2xxllnc.connections.vrije-berichten.timeout: "{{ .timeout }}"
+  openforms2xxllnc.connections.vrije-berichten.auth-alias: "{{ .authAlias }}"
   {{- end }}
 
   {{- with .notificatiesApi }}

--- a/charts/openforms2xxllnc/values.yaml
+++ b/charts/openforms2xxllnc/values.yaml
@@ -449,24 +449,30 @@ openforms2xxllnc:
     ## @skip openforms2xxllnc.connections.beantwoordVraag [object]
     ## @param openforms2xxllnc.connections.beantwoordVraag.endpoint [string] Endpoint at which the zs-dms BeantwoordVraag binding is served.
     ## @param openforms2xxllnc.connections.beantwoordVraag.timeout Timeout used zs-dms BeantwoordVraag calls.
+    ## @param openforms2xxllnc.connections.beantwoordVraag.authAlias AuthAlias used zs-dms BeantwoordVraag calls.
     ##
     beantwoordVraag:
       endpoint: "https://zs-dms/generic/zds/BeantwoordVraag"
       timeout: 60000
+      authAlias: "zaakdms-api"
     ## @skip openforms2xxllnc.connections.ontvangAsynchroon [object]
     ## @param openforms2xxllnc.connections.ontvangAsynchroon.endpoint [string] Endpoint at which the zs-dms OntvangAsynchroon binding is served.
     ## @param openforms2xxllnc.connections.ontvangAsynchroon.timeout Timeout used zs-dms OntvangAsynchroon calls.
+    ## @param openforms2xxllnc.connections.ontvangAsynchroon.authAlias AuthAlias used zs-dms OntvangAsynchroon calls.
     ##
     ontvangAsynchroon:
       endpoint: "https://zs-dms/generic/zds/OntvangAsynchroon"
       timeout: 60000
+      authAlias: "zaakdms-api"
     ## @skip openforms2xxllnc.connections.vrijeBerichten [object]
     ## @param openforms2xxllnc.connections.vrijeBerichten.endpoint [string] Endpoint at which the zs-dms VrijBericht binding is served.
     ## @param openforms2xxllnc.connections.vrijeBerichten.timeout Timeout used zs-dms VrijBericht calls.
+    ## @param openforms2xxllnc.connections.vrijeBerichten.authAlias AuthAlias used zs-dms VrijBericht calls.
     ##
     vrijeBerichten:
       endpoint: "https://zs-dms/generic/zds/VrijBericht"
       timeout: 60000
+      authAlias: "zaakdms-api"
     ## @skip openforms2xxllnc.connections.notificatiesApi [object]
     ## @param openforms2xxllnc.connections.notificatiesApi.rootUrl [string] Root url of the 'Notificaties API' that is used to subscribe at.
     ## @param openforms2xxllnc.connections.notificatiesApi.timeout Timeout used in 'Notificaties API' calls.


### PR DESCRIPTION
A new auth-alias added and its password value will be used in the header of the request that are done to zds side.