### PR TITLE
Drill replace health probes

### DIFF
--- a/charts/drill/templates/statefulset.yaml
+++ b/charts/drill/templates/statefulset.yaml
@@ -55,25 +55,19 @@ spec:
               name: data
           startupProbe:
             {{- toYaml .Values.startupProbe | nindent 12 }}
-            exec:
-              command:
-                - /bin/bash
-                - -c
-                - "${DRILL_HOME}/bin/drillbit.sh status"
+            httpGet:
+              path: /
+              port: web
           readinessProbe:
             {{- toYaml .Values.readinessProbe | nindent 12 }}
-            exec:
-              command:
-                  - /bin/bash
-                  - -c
-                  - "${DRILL_HOME}/bin/drillbit.sh status"
+            httpGet:
+              path: /
+              port: web
           livenessProbe:
             {{- toYaml .Values.livenessProbe | nindent 12 }}
-            exec:
-              command:
-                - /bin/bash
-                - -c
-                - "${DRILL_HOME}/bin/drillbit.sh status"
+            httpGet:
+              path: /
+              port: web
           lifecycle:
             preStop:
               exec:
@@ -121,8 +115,8 @@ spec:
             {{- end }}
         {{- if .Values.persistence.enabled }}
         -  name: {{ template "drill.fullname" . }}-data
-           persistentVolumeClaim:
-             claimName: {{ .Values.persistence.existingClaim | default (printf "%s-%s" ( include "drill.fullname" . ) "data") }}
+            persistentVolumeClaim:
+            claimName: {{ .Values.persistence.existingClaim | default (printf "%s-%s" ( include "drill.fullname" . ) "data") }}
         {{- else }}
         - name: {{ template "drill.fullname" . }}-data
           emptyDir: { }

--- a/charts/drill/templates/statefulset.yaml
+++ b/charts/drill/templates/statefulset.yaml
@@ -55,19 +55,25 @@ spec:
               name: data
           startupProbe:
             {{- toYaml .Values.startupProbe | nindent 12 }}
-            httpGet:
-              path: /
-              port: web
+            exec:
+              command:
+                - /bin/bash
+                - -c
+                - "${DRILL_HOME}/bin/drillbit.sh status"
           readinessProbe:
             {{- toYaml .Values.readinessProbe | nindent 12 }}
-            httpGet:
-              path: /
-              port: web
+            exec:
+              command:
+                - /bin/bash
+                - -c
+                - "curl http://localhost:8047/"
           livenessProbe:
             {{- toYaml .Values.livenessProbe | nindent 12 }}
-            httpGet:
-              path: /
-              port: web
+            exec:
+              command:
+                - /bin/bash
+                - -c
+                - "${DRILL_HOME}/bin/drillbit.sh status"
           lifecycle:
             preStop:
               exec:
@@ -114,7 +120,7 @@ spec:
             secretName: {{ template "drill.fullname" . }}-users
             {{- end }}
         {{- if .Values.persistence.enabled }}
-        -  name: {{ template "drill.fullname" . }}-data
+        - name: {{ template "drill.fullname" . }}-data
           persistentVolumeClaim:
             claimName: {{ .Values.persistence.existingClaim | default (printf "%s-%s" ( include "drill.fullname" . ) "data") }}
         {{- else }}

--- a/charts/drill/templates/statefulset.yaml
+++ b/charts/drill/templates/statefulset.yaml
@@ -115,7 +115,7 @@ spec:
             {{- end }}
         {{- if .Values.persistence.enabled }}
         -  name: {{ template "drill.fullname" . }}-data
-            persistentVolumeClaim:
+          persistentVolumeClaim:
             claimName: {{ .Values.persistence.existingClaim | default (printf "%s-%s" ( include "drill.fullname" . ) "data") }}
         {{- else }}
         - name: {{ template "drill.fullname" . }}-data


### PR DESCRIPTION
Replace the Apache Drill readiness probe with curl command (instead of the current drillbit.sh script call) to ensure the pod is actually reachable when health check succeeds.