### PR TITLE
fix: Change zookeeper reference to legacy repository

### DIFF
--- a/charts/drill/values.yaml
+++ b/charts/drill/values.yaml
@@ -86,6 +86,15 @@ livenessProbe:
   failureThreshold: 6
   successThreshold: 1
 
+## Update the location of bitnami images to the legacy repository
+## Bitnami has moved their images to a new location since 2025-08-28
+## No more updates will be done to the legacy images, but they will remain available
+## Eventually a new source for ZooKeeper will be needed, to keep receiving updates
+zookeeper:
+  image:
+    repository: bitnamilegacy/zookeeper
+
+
 ## Drill container's resource requests and limits
 ## ref: https://kubernetes.io/docs/user-guide/compute-resources/
 ## @param resources [object] Set the resources for the Drill containers


### PR DESCRIPTION
Since bitnami images are no longer available on their old repository, this fixes "image not found" issues for future deployments by changing the location of the image to their legacy repository.

Eventually a new source for zookeeper images needs to be found to get updates, since the legacy images will not be updated.